### PR TITLE
Use elm-elixir-starter image for Circle CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ There are a few things that would make this more useful:
 
 * There are a bunch of steps to customize the repo; the string replacement and file moving could probably be scripted.
 * Elixir compiles each time you execute a `docker-compose run` command,/elm even though the Dockerfile includes `mix compile`.
-* Circle CI doesn't yet run Elm linting
-* Circle CI runs on a different, easier-to-set-up base image than Docker
 * `scripts/lint-elm.sh` feels a bit janky (I'm no bash expert), but is necessary given [this
   elm-make issue](https://github.com/elm-lang/elm-make/issues/108)
 * It doesn't start up with any cute images or instructions.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To set up a new project, you'll want to set up a few things:
 * Change the project name in web/templates/layout/app.html.eex
 * Change the database name in `docker-compose.yml`
 * Update the project details in `elm/elm-package.json`
-* Update `scripts/lint-elm.sh`, changing `arsduo` to the username you put in `elm-package.json`
+* Update `scripts/elm-lint.sh`, changing `arsduo` to the username you put in `elm-package.json`
 
 ### Set up credentials
 
@@ -68,7 +68,7 @@ There are a few things that would make this more useful:
 
 * There are a bunch of steps to customize the repo; the string replacement and file moving could probably be scripted.
 * Elixir compiles each time you execute a `docker-compose run` command,/elm even though the Dockerfile includes `mix compile`.
-* `scripts/lint-elm.sh` feels a bit janky (I'm no bash expert), but is necessary given [this
+* `scripts/elm-lint.sh` feels a bit janky (I'm no bash expert), but is necessary given [this
   elm-make issue](https://github.com/elm-lang/elm-make/issues/108)
 * It doesn't start up with any cute images or instructions.
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,3 +18,4 @@ jobs:
     - run: mix deps.get
     - run: mix test
     - run: mix credo
+    - run: yarn lint

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/arsduo/commonplace-feeds
     docker:
-      - image: trenpixster/elixir:1.4.1
+      - image: arsduo/elm-elixir-starter
         environment:
           PG_USER: ubuntu
           PD_DB: circle_test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin",
-    "lint": "./scripts/lint-elm.sh"
+    "lint": "bash ./scripts/elm-lint.sh"
   },
   "dependencies": {
     "phoenix": "file:deps/phoenix",

--- a/scripts/elm-lint.sh
+++ b/scripts/elm-lint.sh
@@ -6,7 +6,7 @@ rm -rf elm-stuff/build-artifacts/0.18.0/arsduo
 # First, does it compile successfully?
 elm-make Main.elm --yes --output /tmp/elm-linting.html --warn &> /tmp/elm-linting-output
 if [[ $? -ne 0 ]]; then
-  echo "Failed to compile Elm!\n\n"
+  echo "Failed to compile Elm!"
   cat /tmp/elm-linting-output
   exit 1
 fi
@@ -14,11 +14,11 @@ fi
 # Second, were there any linter warnings?
 grep WARNINGS /tmp/elm-linting-output > /dev/null
 if [[ $? -eq 0 ]]; then
-  echo "\nElm linting failed!\n\n"
+  echo "\nElm linting failed!"
   cat /tmp/elm-linting-output
   exit 1
 fi
 
-echo "Compiling and linting succeeded!\n\n"
+echo "Compiling and linting succeeded!"
 cat /tmp/elm-linting-output
 exit 0


### PR DESCRIPTION
Instead of testing on a random Elixir base image, we should run our tests on the actual image built by the repository. Now that I've finally configured a Docker account and figured out how to push the image, this PR switches Circle to the arsduo/elm-elixir-starter image and adds Elm linting.