### PR TITLE
Install Elm Packages when building Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN mix deps.get
 ADD . .
 RUN mix compile
 
+# Install all Elm dependencies
+RUN cd elm && elm-package install --yes
+
 # Exposes this port from the docker container to the host machine
 EXPOSE 4000
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ There are a few things that would make this more useful:
 * Elixir compiles each time you execute a `docker-compose run` command,/elm even though the Dockerfile includes `mix compile`.
 * `scripts/elm-lint.sh` feels a bit janky (I'm no bash expert), but is necessary given [this
   elm-make issue](https://github.com/elm-lang/elm-make/issues/108)
+* Circle CI compiles all the Elixir files for both testing and linting
 * It doesn't start up with any cute images or instructions.
 
 Overall, I'm not an expert on Elm, Elixir, or Docker, so there may well be better ways to


### PR DESCRIPTION
We know at build time which Elm packages we'll need to run the app, so let's install them as part of the image rather than wait until it's needed (for instance, by CI).