### PR TITLE
Use docker-compose env_file for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,8 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-
-# /priv/static/
-#
-# Ignore secret config
-config/secret_config.exs
-secrets.sh
+# Local development configuration
+development.env
 
 # Don't check in node modules
 /node_modules

--- a/README.md
+++ b/README.md
@@ -56,13 +56,7 @@ To set up a new project, you'll want to set up a few things:
 * Change the database name in `docker-compose.yml`
 * Update the project details in `elm/elm-package.json`
 * Update `scripts/elm-lint.sh`, changing `arsduo` to the username you put in `elm-package.json`
-
-### Set up credentials
-
-* Set up a [Twitter app](https://apps.twitter.com/) and update the config
-  appropriately in config/twitter.exs
-* Set a Phoenix secret key in `config/config.exs`
-* Set a Guardian secret key (for auth) in `config/config.exs`
+* `cp development.env.example development.env` and configure your [Twitter app](https://apps.twitter.com/) and other settings appropriately
 
 ## Known issues / to do
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,8 @@ jobs:
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
     environment:
-      - PHOENIX_SECRET_KEY_BASE: 26b18785843693e1a3e81d82f92223c3
-      - GUARDIAN_SECRET_KEY: f4dc9536a7bee266b05b1910fc856082
+      - PHOENIX_SECRET_KEY_BASE: 26b18785843693e1a3e81d82f92223c37844a2ab0f042a87e87481e75bd55a7a
+      - GUARDIAN_SECRET_KEY: f4dc9536a7bee266b05b1910fc85608288e044c649761b50e9d545445f10e1d6
     steps:
     - checkout
     - run: mix deps.get

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,9 @@ jobs:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
+    environment:
+      - PHOENIX_SECRET_KEY_BASE: 26b18785843693e1a3e81d82f92223c3
+      - GUARDIAN_SECRET_KEY: f4dc9536a7bee266b05b1910fc856082
     steps:
     - checkout
     - run: mix deps.get

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,7 @@ config :elmelixirstarter,
 # Configures the endpoint
 config :elmelixirstarter, Elmelixirstarter.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "NOT A SECRET KEY REALLYNOT A SECRET KEY REALLYNOT A SECRET KEY REALLY",
+  secret_key_base: System.get_env("PHOENIX_SECRET_KEY_BASE"),
   render_errors: [view: Elmelixirstarter.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Elmelixirstarter.PubSub,
            adapter: Phoenix.PubSub.PG2]
@@ -50,7 +50,7 @@ config :guardian, Guardian,
   allowed_drift: 2000,
   verify_issuer: true, # optional
   # replace this before production, obviously 💻
-  secret_key: "ANOTHER SECRET KEY YOU NEEDANOTHER SECRET KEY YOU NEEDANOTHER SECRET KEY YOU NEED",
+  secret_key: System.get_env("GUARDIAN_SECRET_KEY"),
   serializer: Elmelixirstarter.GuardianSerializer
 
 # Import environment specific config. This must remain at the bottom

--- a/development.env.example
+++ b/development.env.example
@@ -1,0 +1,16 @@
+# Phoenix settings
+MIX_ENV=dev
+# These should be sufficiently large random string values
+PHOENIX_SECRET_KEY_BASE=
+GUARDIAN_SECRET_KEY=
+
+# Postgres settings
+PG_HOST=db
+PG_USER=postgres
+PG_PASS=postgres
+PG_DB=elmelixirstarter_dev
+
+# Twitter settings
+TWITTER_CONSUMER_KEY=
+TWITTER_CONSUMER_SECRET=
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.0'
+version: '3.0'
 
 services:
   web:
@@ -10,14 +10,8 @@ services:
      - db
     depends_on:
      - db
-    environment:
-     - MIX_ENV=dev
-     - PG_HOST=db
-     - PG_USER=postgres
-     - PG_PASS=postgres
-     - PG_DB=elmelixirstarter_dev
-     - TWITTER_CONSUMER_KEY=YOUR_TWITTER_CONSUMER_KEY
-     - TWITTER_CONSUMER_SECRET=YOUR_TWITTER_CONSUMER_SECRET
+    env_file:
+     - development.env
     volumes:
      - .:/usr/src/app
     # allow attaching directly to the container, for debugging


### PR DESCRIPTION
The current configuration is kinda awkward. Users of the starter project have to customize several different values, some of which are blank and others of which are filled witth dummy values; I, on the other hand, can't put in real values for things like Twitter config for fear of committing them.

Fortunately, docker-compose v3 supports [env files](https://docs.docker.com/compose/compose-file/#env_file), which makes it really easy to have a versioned sample file and an unversioned file with real values. That way, all that a new user needs to customize is in one straightforward place; I, in turn, can develop straightforwardly.