### PR TITLE
Use env file for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   db:
     image: postgres
-    environment:
-      - POSTGRES_PASSWORD=postgres
+    env_file:
+     - development.env
     volumes:
       - ./postgres:/var/lib/postgresql


### PR DESCRIPTION
We should use the same env file (and thus the same environment variables) for the Postgres container as well as the web.