### PR TITLE
Get tests working locally

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -12,8 +12,14 @@ config :logger, level: :warn
 # Configure your database
 config :elmelixirstarter, Elmelixirstarter.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "postgres",
-  password: "postgres",
+  hostname: System.get_env("PG_HOST") || "localhost",
+  username: System.get_env("PG_USER") || "postgres",
+  password: System.get_env("PG_PASS") || "postgres",
   database: "elmelixirstarter_test",
-  hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :guardian, Guardian,
+  secret_key: "SOME FAKE LONG SECRET KEY THAT WORKS FOR TESTS 1234567890 1234567890"
+
+config :elmelixirstarter, Elmelixirstarter.Endpoint,
+  secret_key_base: "SOME FAKE LONG SECRET KEY BASE THAT WORKS FOR TESTS 1234567890 1234567890"


### PR DESCRIPTION
It turns out we can get tests working outside the Docker environment by providing fake secret keys and fallback database configuration. Nothing we'd want to do for any other environment, but anything we can do to make tests as easy to run as possible is worth it.

Closes #15.