### PR TITLE
Remove warnings from code

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Elmelixirstarter.Mixfile do
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
      {:dialyxir, "~> 0.4", only: [:dev], runtime: false},
-     {:credo, "~> 0.8.0-rc6", only: [:dev, :test], runtime: false},
+     {:credo, "~> 0.8.0-rc7", only: [:dev, :test], runtime: false},
      {:ex_machina, "~> 1.0", only: [:dev, :test]}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.1.0", "d9637f0fe7f0727efc8d703a9cfc2cf9e67fd11c6f7a22d35be687e44441d734", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.2.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "credo": {:hex, :credo, "0.8.0-rc6", "19805638f696cc2e5f23dad7ea94558ff31b90711960bbd754e097e1624ba699", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "credo": {:hex, :credo, "0.8.0", "187ce36098afef67baa503d0bb3ec047953c88e4c662591371d15ae9ce150119", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -66,7 +66,7 @@ defmodule Elmelixirstarter.AuthControllerTest do
       conn = build_conn()
       conn = assign(conn, :ueberauth_auth, context[:ueberauth_params])
 
-      conn = post conn, "/auth/twitter/callback"
+      post conn, "/auth/twitter/callback"
 
       user = (from u in User, where: u.twitter_user_id == ^context[:twitter_uid]) |> Repo.one!
       assert user.name == context[:name]
@@ -97,7 +97,7 @@ defmodule Elmelixirstarter.AuthControllerTest do
       conn = build_conn()
       conn = assign(conn, :ueberauth_auth, context[:ueberauth_params])
 
-      conn = post conn, "/auth/twitter/callback"
+      post conn, "/auth/twitter/callback"
 
       user = (from u in User, where: u.twitter_user_id == ^context[:twitter_uid]) |> Repo.one!
       assert user.name == context[:name]

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -1,14 +1,12 @@
 defmodule Elmelixirstarter.UserControllerTest do
   use Elmelixirstarter.ConnCase
 
-  alias Elmelixirstarter.User
-
   test "#me requires a login", %{conn: conn} do
     conn = get conn, user_path(conn, :me)
     assert json_response(conn, 401) == Elmelixirstarter.AuthErrorHandler.unauthenticated_response
   end
 
-  test "#me renders the user", %{conn: conn} do
+  test "#me renders the user" do
     user = insert(:user)
     conn = guardian_login(user)
 

--- a/test/lib/guardian_serializer_test.exs
+++ b/test/lib/guardian_serializer_test.exs
@@ -2,8 +2,6 @@ defmodule Elmelixirstarter.GuardianSerializerTest do
   use Elmelixirstarter.ModelCase
   import Elmelixirstarter.Factory
 
-  alias Elmelixirstarter.Repo
-  alias Elmelixirstarter.User
   alias Elmelixirstarter.GuardianSerializer
 
   describe "#for_token" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -37,9 +37,9 @@ defmodule Elmelixirstarter.ConnCase do
       # We need a way to get into the connection to login a user
       # We need to use the bypass_through to fire the plugs in the router
       # and get the session fetched.
-      def guardian_login(%Elmelixirstarter.User{} = user), do: guardian_login(conn(), user, :token, [])
-      def guardian_login(%Elmelixirstarter.User{} = user, token), do: guardian_login(conn(), user, token, [])
-      def guardian_login(%Elmelixirstarter.User{} = user, token, opts), do: guardian_login(conn(), user, token, opts)
+      def guardian_login(%Elmelixirstarter.User{} = user), do: guardian_login(build_conn(), user, :token, [])
+      def guardian_login(%Elmelixirstarter.User{} = user, token), do: guardian_login(build_conn(), user, token, [])
+      def guardian_login(%Elmelixirstarter.User{} = user, token, opts), do: guardian_login(build_conn(), user, token, opts)
 
       def guardian_login(%Plug.Conn{} = conn, user), do: guardian_login(conn, user, :token, [])
       def guardian_login(%Plug.Conn{} = conn, user, token), do: guardian_login(conn, user, token, [])

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -2,7 +2,6 @@ defmodule Elmelixirstarter.UserViewTest do
   use Elmelixirstarter.ModelCase
 
   alias Elmelixirstarter.UserView
-  alias Elmelixirstarter.User
 
   import Elmelixirstarter.Factory
 


### PR DESCRIPTION
This resolves a bunch of Elixir warnings that showed up when running tests and also updates Credo to not spit out some warnings on Circle CI.