### PR TITLE
Avoid recompilation of code on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,5 +20,5 @@ jobs:
     - checkout
     - run: mix deps.get
     - run: mix test
-    - run: mix credo
+    - run: MIX_ENV=test mix credo
     - run: yarn lint


### PR DESCRIPTION
Right now on Circle, `mix test` runs with `MIX_ENV=test` and `mix credo` runs with `MIX_ENV=dev`. This causes the code to get compiled twice, which adds an extra minute or so to the test time (a lot when the tests run for just three minutes). This PR sets credo to run in the test environment and reuse the previously-compiled code.