### PR TITLE
Remove old reference to Twitter in app.js

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -25,7 +25,3 @@ import "phoenix_html"
 // guidance
 const elmDiv = document.querySelector('#elm-container');
 const elmApp = Elm.Main.embed(elmDiv);
-
-elmApp.ports.openTwitterDialog.subscribe((url) => {
-  window.open(url)
-})


### PR DESCRIPTION
The app the starter kit was based on used an [Elm port](https://guide.elm-lang.org/interop/javascript.html) to open up a dialog to post to Twitter. That reference hung around after everything else was cleaned up, throwing a Javascript error. This removes that.